### PR TITLE
Add glyph-watering-eyeballs short URL redirect

### DIFF
--- a/glyph-watering-eyeballs/index.html
+++ b/glyph-watering-eyeballs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Glyph's Happy Eyeballs state machine branch</title>
+  <link rel="canonical" href="https://github.com/twisted/twisted/compare/trunk...glyph:statemachine-hostnameendpoint">
+  <meta http-equiv="refresh" content="0; url=https://github.com/twisted/twisted/compare/trunk...glyph:statemachine-hostnameendpoint">
+</head>
+<body>
+  <p>Redirecting to <a href="https://github.com/twisted/twisted/compare/trunk...glyph:statemachine-hostnameendpoint">https://github.com/twisted/twisted/compare/trunk...glyph:statemachine-hostnameendpoint</a>&hellip;</p>
+</body>
+</html>


### PR DESCRIPTION
Redirects to Glyph's statemachine-hostnameendpoint branch on twisted/twisted, used in the Happy Eyeballs lightning talk.